### PR TITLE
Support None returned from transition functions

### DIFF
--- a/discordmenu/embed/emoji.py
+++ b/discordmenu/embed/emoji.py
@@ -1,9 +1,10 @@
 class EmbedMenuEmojiConfig:
-    def __init__(self, delete_message="❌"):
+    def __init__(self, delete_message="❌", unsupported_action="🚫"):
         self.delete_message = delete_message
+        self.unsupported_action = unsupported_action
 
     def to_list(self):
-        return [self.delete_message]
+        return [self.delete_message, self.unsupported_action]
 
 
 DEFAULT_EMBED_MENU_EMOJI_CONFIG = EmbedMenuEmojiConfig()

--- a/discordmenu/embed/emoji.py
+++ b/discordmenu/embed/emoji.py
@@ -1,10 +1,10 @@
 class EmbedMenuEmojiConfig:
-    def __init__(self, delete_message="❌", unsupported_action="🚫"):
+    def __init__(self, delete_message="❌", unsupported_transition="🚫"):
         self.delete_message = delete_message
-        self.unsupported_action = unsupported_action
+        self.unsupported_transition = unsupported_transition
 
     def to_list(self):
-        return [self.delete_message, self.unsupported_action]
+        return [self.delete_message, self.unsupported_transition]
 
 
 DEFAULT_EMBED_MENU_EMOJI_CONFIG = EmbedMenuEmojiConfig()

--- a/discordmenu/embed/menu.py
+++ b/discordmenu/embed/menu.py
@@ -21,7 +21,7 @@ class EmbedMenu:
                  transitions: Dict[str, NextEmbedControlFunc],
                  initial_pane: Callable,
                  emoji_config: EmbedMenuEmojiConfig = DEFAULT_EMBED_MENU_EMOJI_CONFIG,
-                 unsupported_transition_announce_timeout: int = 10
+                 unsupported_transition_announce_timeout: int = 3
                  ):
         self.emoji_config = emoji_config
         self.transitions = transitions
@@ -46,10 +46,8 @@ class EmbedMenu:
             return
 
         new_control = await transition_func(message, ims, **data)
-
         if new_control is not None:
             current_emojis = [e.emoji for e in message.reactions]
-
             next_emojis = new_control.emoji_buttons + [emoji_cache.get_emoji(self.emoji_config.delete_message)]
 
             emoji_diff = diff_emojis_raw(current_emojis, next_emojis)

--- a/discordmenu/embed/menu.py
+++ b/discordmenu/embed/menu.py
@@ -2,7 +2,6 @@ import asyncio
 from typing import Callable, List, Optional, Coroutine, Dict
 
 from discord import Message, RawReactionActionEvent
-
 from discordmenu.discord_client import remove_reaction, update_embed_control, send_embed_control, \
     diff_emojis_raw
 from discordmenu.embed.control import EmbedControl
@@ -11,8 +10,6 @@ from discordmenu.embed.view_state import ViewState
 from discordmenu.emoji.emoji import discord_emoji_to_emoji_name
 from discordmenu.emoji.emoji_cache import emoji_cache
 from discordmenu.reaction_filter import ReactionFilter
-
-from discordmenu.errors import UnsupportedPaneType
 
 _IntraMessageState = Dict
 NextEmbedControlFunc = Callable[[Optional[Message], Dict, _IntraMessageState], Coroutine[None, None, EmbedControl]]
@@ -23,11 +20,14 @@ class EmbedMenu:
                  reaction_filters: List[ReactionFilter],
                  transitions: Dict[str, NextEmbedControlFunc],
                  initial_pane: Callable,
-                 emoji_config: EmbedMenuEmojiConfig = DEFAULT_EMBED_MENU_EMOJI_CONFIG):
+                 emoji_config: EmbedMenuEmojiConfig = DEFAULT_EMBED_MENU_EMOJI_CONFIG,
+                 unsupported_transition_announce_timeout: int = 10
+                 ):
         self.emoji_config = emoji_config
         self.transitions = transitions
         self.reaction_filters = reaction_filters
         self.initial_pane = initial_pane
+        self.unsupported_transition_announce_timeout = unsupported_transition_announce_timeout
 
     async def create(self, ctx, state: ViewState):
         embed_control: EmbedControl = self.initial_pane(state)
@@ -45,25 +45,26 @@ class EmbedMenu:
                 await message.delete()
             return
 
-        try:
-            new_control = await transition_func(message, ims, **data)
+        new_control = await transition_func(message, ims, **data)
 
+        if new_control is not None:
             current_emojis = [e.emoji for e in message.reactions]
 
             next_emojis = new_control.emoji_buttons + [emoji_cache.get_emoji(self.emoji_config.delete_message)]
 
             emoji_diff = diff_emojis_raw(current_emojis, next_emojis)
             await update_embed_control(message, new_control, emoji_diff)
-        except UnsupportedPaneType:
-            await message.add_reaction(self.emoji_config.unsupported_action)
+        elif self.emoji_config.unsupported_transition is not None:
+            # allow the reporting of an unsupported transition to be nulled by config
+            await message.add_reaction(self.emoji_config.unsupported_transition)
             asyncio.create_task(self.remove_unsupported_action_response(message))
 
         if message.guild:
             await remove_reaction(message, emoji_clicked, member.id)
 
     async def remove_unsupported_action_response(self, message):
-        await asyncio.sleep(3)
-        await message.clear_reaction(self.emoji_config.unsupported_action)
+        await asyncio.sleep(self.unsupported_transition_announce_timeout)
+        await message.clear_reaction(self.emoji_config.unsupported_transition)
 
     async def should_respond_raw(self, message, event: RawReactionActionEvent):
         for reaction_filter in self.reaction_filters:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="discord-menu",
-    version="0.12.0",
+    version="0.13.0",
     author="The Tsubotki Team",
     author_email="69992611+TsubakiBotPad@users.noreply.github.com",
     license="Apache-2.0 License",


### PR DESCRIPTION
This PR supports showing disallowed actions when scrolling through numberscroll or otherwise by showing a disallowed emoji that can be configured via `unsupported_transition`. This is accomplished by having transition functions return `None`.