### PR TITLE
Add Closable Menu

### DIFF
--- a/discordmenu/menu/base.py
+++ b/discordmenu/menu/base.py
@@ -23,3 +23,20 @@ class PMenuable(Protocol[T]):
 
     def __repr__(self):
         return str(type(self))
+
+
+class PMenuableCM(Protocol[T]):
+    @classmethod
+    def menu(cls) -> EmbedMenu:
+        ...
+
+    @classmethod
+    async def embed_from_message(cls, message: Optional[Message], ims, **data) -> EmbedWrapper:
+        ...
+
+    @classmethod
+    def embed(cls, state: T) -> Optional[EmbedWrapper]:
+        ...
+
+    def __repr__(self):
+        return str(type(self))

--- a/discordmenu/menu/closable_menu.py
+++ b/discordmenu/menu/closable_menu.py
@@ -1,0 +1,43 @@
+from typing import Dict, Any, Optional, Type
+
+from discord import Message
+
+from discordmenu.embed.menu import EmbedMenu
+from discordmenu.embed.view_state import ViewState
+from discordmenu.embed.wrapper import EmbedWrapper
+from discordmenu.menu.base import PMenuableCM
+
+
+class ClosableMenuViewState(ViewState):
+    def __init__(self, original_author_id: int, menu_type: str, raw_query: str, view_type: str, sub_props: Any):
+        super().__init__(original_author_id, menu_type, raw_query)
+        self.view_type = view_type
+        self.sub_props = sub_props
+
+
+class ClosableMenusBase(PMenuableCM[ClosableMenuViewState]):
+    MENU_TYPE = 'ClosableMenu'
+    message = None
+    view_types: Dict[str, Type] = {}
+
+    @classmethod
+    def menu(cls):
+        # Menus added to view_types are independent and only support the default close button.
+        # No additional transitions are defined.
+        embed = EmbedMenu({}, cls.embed)
+        return embed
+
+    @classmethod
+    async def embed_from_message(cls, message: Optional[Message], ims, **data) -> EmbedWrapper:
+        # Because no actions can be taken on the menu, a menu would not need to be constructed from an existing message.
+        # However, one could conceivably save the view state in a view_types dict, extract the menu type, and
+        # reconstruct a menu from an existing message if such a use case arose.
+        pass
+
+    @classmethod
+    def embed(cls, state: ClosableMenuViewState):
+        view_cls = cls.view_types[state.view_type]
+        return EmbedWrapper(
+            view_cls(state, state.sub_props),
+            []
+        )

--- a/discordmenu/menu/listener/menu_map.py
+++ b/discordmenu/menu/listener/menu_map.py
@@ -1,15 +1,15 @@
 import json
 from collections import UserDict
 from dataclasses import dataclass
-from typing import Optional, Type
+from typing import Optional, Type, Union
 
 from discordmenu.embed.transitions import EmbedTransitions
-from discordmenu.menu.base import PMenuable
+from discordmenu.menu.base import PMenuable, PMenuableCM
 
 
 @dataclass
 class MenuMapEntry:
-    menuable: PMenuable
+    menuable: Union[PMenuable, PMenuableCM]
     transitions: Type[EmbedTransitions]
     cog_name: Optional[str] = None
 

--- a/test/testcog/examples/closable_menu.py
+++ b/test/testcog/examples/closable_menu.py
@@ -1,0 +1,63 @@
+from discordmenu.embed.base import Box
+from discordmenu.embed.components import EmbedMain, EmbedField
+from discordmenu.embed.text import Text
+from discordmenu.embed.view import EmbedView
+from discordmenu.menu.closable_menu import ClosableMenusBase, ClosableMenuViewState
+from discordmenu.menu.footer import embed_footer_with_state
+
+
+class ClosableView1Props:
+    VIEW_TYPE = 'ClosableViewType1'
+
+    def __init__(self, inner_message: str):
+        self.inner_message = inner_message
+
+
+class ClosableView1(EmbedView):
+    def __init__(self, state: ClosableMenuViewState, props: ClosableView1Props):
+        super().__init__(
+            EmbedMain(),
+            embed_footer=embed_footer_with_state(state),
+            embed_fields=[
+                EmbedField(
+                    'Closable View Type 1',
+                    Box(
+                        Text('Lorem ipsum dolor sit amet, consectetur adipiscing elit. In quis bibendum mi, ultricies '
+                             'hendrerit est. Pellentesque eget molestie magna, vitae pulvinar arcu.'),
+                        Text(props.inner_message)
+                    )
+                ),
+            ]
+        )
+
+
+class ClosableView2Props:
+    VIEW_TYPE = 'ClosableViewType2'
+
+    def __init__(self, inner_message: str):
+        self.inner_message = inner_message
+
+
+class ClosableView2(EmbedView):
+    def __init__(self, state: ClosableMenuViewState, props: ClosableView2Props):
+        super().__init__(
+            EmbedMain(),
+            embed_footer=embed_footer_with_state(state),
+            embed_fields=[
+                EmbedField(
+                    'Closable View Type 2',
+                    Box(
+                        Text('Lorem ipsum dolor sit amet, consectetur adipiscing elit. In quis bibendum mi, ultricies '
+                             'hendrerit est. Pellentesque eget molestie magna, vitae pulvinar arcu.'),
+                        Text(props.inner_message)
+                    )
+                ),
+            ]
+        )
+
+
+class ClosableMenus(ClosableMenusBase):
+    view_types = {
+        ClosableView1Props.VIEW_TYPE: ClosableView1,
+        ClosableView2Props.VIEW_TYPE: ClosableView2,
+    }

--- a/test/testcog/examples/rich_text_menu.py
+++ b/test/testcog/examples/rich_text_menu.py
@@ -74,7 +74,6 @@ class RichTextView(EmbedView):
                          'hendrerit est. Pellentesque eget molestie magna, vitae pulvinar arcu.')
                 ),
             ]
-
         )
 
 

--- a/test/testcog/main.py
+++ b/test/testcog/main.py
@@ -4,12 +4,14 @@ import discord
 from redbot.core import commands
 
 from discordmenu.embed.transitions import EmbedTransitions
+from discordmenu.menu.closable_menu import ClosableMenuViewState
 from discordmenu.menu.listener.menu_listener import MenuListener
 from discordmenu.menu.listener.menu_map import MenuMap, MenuMapEntry
 from discordmenu.menu.simple_tabbed_menu import SimpleTabbedMenu, SimpleTabbedMenuTransitions
 from discordmenu.menu.simple_text_menu import SimpleTextMenu
 from discordmenu.menu.view.simple_tabbed_view import SimpleTabbedViewState
 from discordmenu.menu.view.simple_text_view import SimpleTextViewState
+from .examples.closable_menu import ClosableMenus, ClosableView1Props, ClosableView2Props
 from .examples.rich_text_menu import RichTextViewState, RichTextMenu, RichTextMenuTransitions
 
 logger = logging.getLogger('test-bot')
@@ -18,6 +20,7 @@ menu_map = MenuMap()
 menu_map[SimpleTextMenu.MENU_TYPE] = MenuMapEntry(SimpleTextMenu, EmbedTransitions)
 menu_map[SimpleTabbedMenu.MENU_TYPE] = MenuMapEntry(SimpleTabbedMenu, SimpleTabbedMenuTransitions)
 menu_map[RichTextMenu.MENU_TYPE] = MenuMapEntry(RichTextMenu, RichTextMenuTransitions)
+menu_map[ClosableMenus.MENU_TYPE] = MenuMapEntry(ClosableMenus, EmbedTransitions)
 
 
 class TestCog(commands.Cog):
@@ -32,16 +35,29 @@ class TestCog(commands.Cog):
         await self.listener.on_raw_reaction_update(payload)
 
     @commands.command(aliases=['t'])
-    async def simplemenu(self, ctx, *, member: discord.Member = None):
+    async def simplemenu(self, ctx):
         vs = SimpleTextViewState("Hello World!")
         await SimpleTextMenu.menu().create(ctx, vs)
 
     @commands.command(aliases=['t2'])
-    async def simpletabbedmenu(self, ctx, *, member: discord.Member = None):
+    async def simpletabbedmenu(self, ctx):
         vs = SimpleTabbedViewState("Initial message.")
-        all_emoji = SimpleTabbedMenuTransitions().all_emoji_names()
         await SimpleTabbedMenu.menu().create(ctx, vs)
 
     @commands.command(aliases=['t3'])
-    async def richtextmenu(self, ctx, *, member: discord.Member = None):
+    async def richtextmenu(self, ctx):
         await RichTextMenu.menu().create(ctx, RichTextViewState())
+
+    @commands.command(aliases=['t4'])
+    async def closablemenu(self, ctx, *, query: str = None):
+        original_author_id = ctx.message.author.id
+        if query == 'type1':
+            props = ClosableView1Props("type 1 message.")
+            vs = ClosableMenuViewState(original_author_id, ClosableMenus.MENU_TYPE, query, ClosableView1Props.VIEW_TYPE,
+                                       props)
+            await ClosableMenus.menu().create(ctx, vs)
+        elif query == 'type2':
+            props = ClosableView2Props("type 2 message.")
+            vs = ClosableMenuViewState(original_author_id, ClosableMenus.MENU_TYPE, query, ClosableView2Props.VIEW_TYPE,
+                                       props)
+            await ClosableMenus.menu().create(ctx, vs)


### PR DESCRIPTION
This PR adds a Closable Menu base type, which allows users to configure any view and have it be a menu with a single close button interaction.

The PR also adds the `PMenuableCM` protocol type for clarity, as the `ClosableMenuBase` extension requires menu types to contain state within their class declaration so that the `view_types` parameter on `ClosableMenuBase` can be modified after module load. Menus of this type are still stateless and idempotent on the bot server.